### PR TITLE
Add configurable package install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![License](https://img.shields.io/github/license/jtprogru/ansible-role-profile)
 ![Ansible Role](https://img.shields.io/ansible/role/52416)
 
-My personal role for configuring a user account on remote Linux servers: it creates a group and a personal user, grants that group passwordless sudo, installs the user's SSH key, and installs vim.
+My personal role for configuring a user account on remote Linux servers: it creates a group and a personal user, grants that group passwordless sudo, installs the user's SSH key, and installs a configurable list of packages.
 
 ## Role Variables
 
@@ -18,6 +18,7 @@ See `defaults/main.yml`. All variables are validated via `meta/argument_specs.ym
 | `profile_key` | `https://github.com/jtprogru.keys` | SSH public key(s) for `authorized_keys`. Accepts a raw key string or an HTTP(S) URL. |
 | `profile_user_shell` | `/bin/bash` | Login shell for the personal user. |
 | `profile_password` | _(unset)_ | Optional user password. When unset, the password is left untouched. |
+| `profile_packages` | `[git, vim]` | Packages installed for the user via the system package manager. |
 
 If you want to manage the user's password, set `profile_password` — ideally encrypted with `ansible-vault`:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,16 @@
----
 # Login name of the personal user to create.
 profile_name: "jtprogru"
-
 # Group granted passwordless sudo via /etc/sudoers.d/10-admins.conf.
 profile_group: "admins"
-
 # SSH public key(s) added to the user's authorized_keys.
 # Accepts a raw key string or an HTTP(S) URL (e.g. GitHub .keys endpoint).
 profile_key: "https://github.com/jtprogru.keys"
-
 # Login shell for the personal user.
 profile_user_shell: "/bin/bash"
-
 # Optional: set `profile_password` (ideally via ansible-vault) to manage the
 # user's password. When undefined, the password is left untouched.
+
+# Packages installed for the user via the system package manager.
+profile_packages:
+  - git
+  - vim

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -4,7 +4,7 @@ argument_specs:
     short_description: Configure a personal account on remote Linux servers
     description:
       - Creates a group and a personal user, grants the group passwordless
-        sudo, installs the user's SSH key and vim.
+        sudo, installs the user's SSH key and a configurable list of packages.
     options:
       profile_name:
         type: str
@@ -32,3 +32,11 @@ argument_specs:
         description: >-
           Optional password for the user (ideally supplied via ansible-vault).
           When omitted, the password is left untouched.
+      profile_packages:
+        type: list
+        elements: str
+        required: false
+        default:
+          - git
+          - vim
+        description: Packages installed for the user via the system package manager.

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -53,7 +53,8 @@ def test_authorized_key(host):
     assert TEST_KEY_MARKER in authorized_keys.content_string
 
 
-def test_vim_installed(host):
-    # Assert the binary rather than a package name: on RHEL family the rpm is
-    # vim-enhanced, on Debian/Ubuntu it is vim.
-    assert host.exists("vim")
+def test_packages_installed(host):
+    # Assert the binaries rather than package names: names differ across
+    # families (e.g. on RHEL vim ships as vim-enhanced, on Debian as vim).
+    for binary in ("git", "vim"):
+        assert host.exists(binary)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,8 @@
     user: "{{ profile_name }}"
     key: "{{ profile_key }}"
 
-- name: "Install vim"
+- name: "Install packages"
   ansible.builtin.package:
-    name: vim
+    name: "{{ item }}"
     state: present
+  loop: "{{ profile_packages }}"


### PR DESCRIPTION
## What

Replace the hardcoded `vim` install task with a configurable `profile_packages` list installed via a `loop`. Defaults to `[git, vim]`.

## Why

Picks up the idea from #3 (thanks @vlegio) — that PR couldn't be merged as-is (based on the pre-refactor layout, plus a mistyped variable name), so it's reimplemented cleanly on current `master`.

## Changes

- `defaults/main.yml` — new `profile_packages` variable
- `tasks/main.yml` — `loop`-based install task replacing hardcoded vim
- `meta/argument_specs.yml` — validation for the new list variable
- `README.md` — role description + variables table
- `molecule/default/tests/test_default.py` — assert each package binary is present

## Notes

Ran locally without `ansible-lint` (not installed in the dev env); CI `make lint`/`make test` covers it.