### PR TITLE
Update galaxy tags

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,5 +28,9 @@ galaxy_info:
     - sudo
     - ssh
     - users
+    - system
+    - packages
+    - provisioning
+    - linux
 
 dependencies: []


### PR DESCRIPTION
Add galaxy tags reflecting the role's scope: `system`, `packages`, `provisioning`, `linux` (on top of the existing `configuration`, `profile`, `sudo`, `ssh`, `users`).

Version will be bumped to `v1.9` by tagging `master` after this merges (the tag push triggers the Galaxy import via the release workflow).