### PR TITLE
Bump CI actions and document CalVer releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: 'jtprogru.profile'
 
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: 'jtprogru.profile'
 
@@ -58,7 +58,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: 'jtprogru.profile'
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ make test-all   # runs ubuntu2604, debian13, rockylinux9
 
 Handy sub-commands during development: `make converge`, `make verify`, `make login`, `make destroy`.
 
+## Releasing
+
+Versions are published to Ansible Galaxy by pushing a git tag: the `release.yml` workflow runs `ansible-galaxy role import` on every tag push.
+
+This role uses **CalVer** tags in the form `YYYY.M.PATCH` (e.g. `2026.7.14`). This is deliberate:
+
+- Galaxy only recognises tags that are valid [SemVer](https://semver.org/) — three components, `MAJOR.MINOR.PATCH`. Two-component tags like `v1.9` are silently ignored and never become an installable version.
+- The role's published history is already CalVer (`2020.12.1` … `2021.2.1`), so any new SemVer like `1.9.0` would rank *below* them and would not become "latest". Continuing CalVer keeps each release strictly greater than the last.
+
+To cut a release, tag `master` and push:
+
+```bash
+git tag -a 2026.7.14 -m "Release 2026.7.14"
+git push origin 2026.7.14
+```
+
+Do **not** use `vX.Y` tags — they do not publish.
+
 ## License
 
 [WTFPL](LICENSE)


### PR DESCRIPTION
## Changes

- **Bump GitHub Actions off the deprecated Node 20 runtime:**
  - `actions/checkout` v4 → v5
  - `actions/setup-python` v5 → v6
  - (`astral-sh/setup-uv@v6` is already current, left as-is)
- **Document the release/versioning scheme** in the README: CalVer (`YYYY.M.PATCH`), and why `vX.Y` tags never publish to Galaxy (not valid SemVer, and would rank below the existing `2021.x` history anyway).

## Why

The release run surfaced a Node 20 deprecation warning, and the Galaxy import logs revealed the `v1.x` tag scheme was never actually publishing versions. This pins the runner and records the tagging convention so it doesn't get repeated.