### PR TITLE
Fix broken Ansible Galaxy badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://img.shields.io/github/actions/workflow/status/jtprogru/ansible-role-profile/ci.yml?branch=master&label=CI)
 ![Release](https://img.shields.io/github/actions/workflow/status/jtprogru/ansible-role-profile/release.yml?label=Release)
 ![License](https://img.shields.io/github/license/jtprogru/ansible-role-profile)
-![Ansible Role](https://img.shields.io/ansible/role/52416)
+[![Ansible Galaxy](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F15131%2F&query=%24.summary_fields.versions%5B0%5D.name&label=galaxy&color=blue)](https://galaxy.ansible.com/ui/standalone/roles/jtprogru/profile/)
 
 My personal role for configuring a user account on remote Linux servers: it creates a group and a personal user, grants that group passwordless sudo, installs the user's SSH key, and installs a configurable list of packages.
 


### PR DESCRIPTION
## Problem

The last badge in the README — `https://img.shields.io/ansible/role/52416` — renders as **404 badge not found**.

Root cause is **not** the role id: shields.io's `ansible/role` service is dead entirely (the Galaxy NG migration took down the old API it queried). Confirmed by testing a known-good role: `geerlingguy.docker` (id 10923) 404s too. So no id would fix it.

## Fix

Replace it with a **dynamic JSON badge** that reads the latest version straight from the still-working Galaxy v1 API (`/api/v1/roles/15131/`), linked to the role page. Renders `galaxy | 2026.7.14` and will track future releases automatically.

## Bonus

While here, verified `2026.7.14` is now the **latest** version on Galaxy (top of `summary_fields.versions`, `modified: 2026-07-14`, new tags all present).